### PR TITLE
fix: carousel image distorted is fixed

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,7 @@
                 </a>
             </div>
           </div>
-          <div class="level-right">
+          <div id="footer-nav" class="level-right">
             {% for item in site.data.navigation %}
                 <a href="{{ site.baseurl }}{{ item.link }}" class="level-item is-blue">
                     {{ item.name }}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,4 @@
-<header class="navbar is-fixed-top" style="background-color: #233265;">
+<header id="navbar-index" class="navbar is-fixed-top" style="background-color: #233265;">
     <div class="container">
       <div class="navbar-brand">
         <a href="/#inicio" class="logo">

--- a/_sass/cda/_footer.scss
+++ b/_sass/cda/_footer.scss
@@ -10,4 +10,20 @@ footer {
   .buttons {
     justify-content: flex-start;
   }
+
+  #footer-nav {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+}
+
+@media (max-width: 1224px) {
+
+  #footer-nav {
+  display: flex;
+  flex-wrap: wrap;
+  flex-flow: column;
+}
+
 }

--- a/_sass/cda/_header.scss
+++ b/_sass/cda/_header.scss
@@ -8,12 +8,14 @@ html {
 
 #inicio .carousel-cell {
   width: 100%;
-  height: 100vh;
+}
+
+#inicio #navbar-index {
+  max-width: 100vw;
 }
 
 #inicio .carousel-cell-image {
   display: block;
-  height: 100vh;
   width: 100vw;
   padding-top: 4rem;
   background-color: #233265;
@@ -22,7 +24,6 @@ html {
 @media (max-width: 768px) {
   #inicio .carousel-cell {
     width: 100%;
-    height: 300px;
     display: flex;
     // margin-top: 15px;
     align-items: center;
@@ -31,7 +32,6 @@ html {
 
   #inicio .carousel-cell-image {
     display: block;
-    height: 222px;
     width: 100vw;
     padding-top: 1rem;
     background-color: #233265;


### PR DESCRIPTION
# O que foi feito?

Imagens do banner da CDA antes ficavam desta forma:

![image](https://github.com/dev-cda/site_cda/assets/65050199/5d8aac6a-56a4-4571-9d51-2e54b266a97f)

O problema foi corrigido:

![image](https://github.com/dev-cda/site_cda/assets/65050199/13002af5-7f7d-4ee3-b330-93ac25933275)
